### PR TITLE
Fixes for PostreSQL 12

### DIFF
--- a/lib/DbState.js
+++ b/lib/DbState.js
@@ -368,8 +368,11 @@ class DbState {
                     if exists(
                         select from information_schema.routines as routines
         
-                        left join pg_catalog.pg_proc as pg_proc on
-                            routines.specific_name = pg_proc.proname || '_' || pg_proc.oid::text
+                        left join pg_namespace
+                            on routines.routine_schema = pg_namespace.nspname
+                        left join pg_proc
+                            on pg_namespace.oid = pg_proc.pronamespace
+                                and routines.routine_name = pg_proc.proname
         
                         where
                             routines.routine_schema = ${ wrapText(func.schema) } and

--- a/lib/parser/syntax/CreateTrigger.js
+++ b/lib/parser/syntax/CreateTrigger.js
@@ -117,7 +117,7 @@ class CreateTrigger extends Syntax {
 
         coach.expectWord("execute");
         coach.skipSpace();
-        coach.expectWord("procedure");
+        coach.expect(new RegExp("procedure|function", "i"));
         coach.skipSpace();
 
         this.procedure = coach.parseSchemaName();


### PR DESCRIPTION
1. ddl-manager/lib/parser/syntax/CreateTrigger.js 
C PostgreSQL 11+ появилось два варианта синтаксиса для создания триггеров

```
create trigger ...
...
execute procedure ...
```
```
create trigger ...
...
execute function ...
```
"function" используется по умолчанию. DDLCoach не может прочитать триггеры в БД.


2. getCheckFreezeFunctionSql

routines.specific_name не гарантированно равен pg_proc.proname || '_' || pg_proc.oid::text

Пример:
> pg_proc.proname = очень_длинное_название_функции
> pg_proc.oid = 1234
> routines.specific_name = очень_длинное_название_фу_1234